### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ package main
 
 import (
     "github.com/didip/tollbooth/v7"
-    "github.com/didip/tollbooth_gin/v7"
+    "github.com/didip/tollbooth_gin"
     "github.com/gin-gonic/gin"
 )
 


### PR DESCRIPTION
The README example code incorrectly includes a version suffix  v7 on the github.com/didip/tollbooth_gin import path.